### PR TITLE
Update for latest release of DocFX

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM mono:latest
 LABEL maintainer="stewmcc<stewmcc@gmail.com>" \
       description="For DocFX building(with mono.)"
 
-ENV DOCFX_VER 2.40.11
+ENV DOCFX_VER 2.40.12
 
 RUN apt-get update && apt-get install unzip wget git -y && \
     wget -q -P /tmp https://github.com/dotnet/docfx/releases/download/v${DOCFX_VER}/docfx.zip && \


### PR DESCRIPTION
Fixes a bug causing DocFX to fail when run under Mono on Linux/MacOS.